### PR TITLE
Increase uvicorn keep alive timeout to 120s

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ COPY . .
 
 RUN pip install .
 
-CMD ["uvicorn", "eventsapi.main:app", "--host", "0.0.0.0", "--port", "80"]
+CMD ["uvicorn", "eventsapi.main:app", "--host", "0.0.0.0", "--port", "80", "--timeout-keep-alive", "120"]


### PR DESCRIPTION
This change is to address rare failures observed under load where the Traefik timeout of 90s being less than that of the default uvicorn might be causing connections to close unexpectedly resulting in 502 errors from Traefik.